### PR TITLE
add '...' argument for predict()

### DIFF
--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -5,235 +5,239 @@
 
 
 RMSE <- function(obs, prd, na.rm=FALSE) {
-	sqrt(mean((obs - prd)^2, na.rm=na.rm))
+  obs <- as.numeric(obs)
+  prd <- as.numeric(prd)
+  sqrt(mean((obs - prd)^2, na.rm=na.rm))
 }
 
 RMSE_null <- function(obs, prd, na.rm=FALSE) {
-	r <- RMSE(obs, prd, na.rm=na.rm)
-	null <- RMSE(obs, mean(obs))
-	(null - r) / null
+  obs <- as.numeric(obs)
+  prd <- as.numeric(prd)
+  r <- RMSE(obs, prd, na.rm=na.rm)
+  null <- RMSE(obs, mean(obs))
+  (null - r) / null
 }
 
 
 
 .auctest <- function(p, a) {
-	w <- stats::wilcox.test(p, a)
-	pauc <- w$p.value
-	auc <- as.vector(w$statistic) / (length(a) * length(p))
-	cbind(auc, pauc)
+  w <- stats::wilcox.test(p, a)
+  pauc <- w$p.value
+  auc <- as.vector(w$statistic) / (length(a) * length(p))
+  cbind(auc, pauc)
 }
 
 
 
 setClass("paModelEvaluation",
-	representation (
-		presence = "vector",
-		absence = "vector",
-		confusion = "matrix",
-		stats = "data.frame",
-		tr_stats = "data.frame",
-		thresholds = "data.frame"
-	)
+         representation (
+           presence = "vector",
+           absence = "vector",
+           confusion = "matrix",
+           stats = "data.frame",
+           tr_stats = "data.frame",
+           thresholds = "data.frame"
+         )
 )
 
 
 
 pa_evaluate <- function(p, a, model=NULL, x=NULL, tr, ...) {
-	if (!is.null(model)) {
-		if (is.null(x)) {
-			p <- predict(model, p, ...)
-			a <- predict(model, a, ...)
-		} else {
-			p <- terra::extract(x, p)
-			p <- predict(model, p, ...)
-			a <- terra::extract(x, a)
-			a <- predict(model, a, ...)
-		}
-	}
-	p <- stats::na.omit(p)
-	a <- stats::na.omit(a)
-	np <- length(p)
-	na <- length(a)
-	if (na == 0 | np == 0) {
-		stop("cannot evaluate a model without absence and presence data that are not NA")
-	}
+  if (!is.null(model)) {
+    if (is.null(x)) {
+      p <- predict(model, p, ...)
+      a <- predict(model, a, ...)
+    } else {
+      p <- terra::extract(x, p)
+      p <- predict(model, p, ...)
+      a <- terra::extract(x, a)
+      a <- predict(model, a, ...)
+    }
+  }
+  p <- stats::na.omit(p)
+  a <- stats::na.omit(a)
+  np <- length(p)
+  na <- length(a)
+  if (na == 0 | np == 0) {
+    stop("cannot evaluate a model without absence and presence data that are not NA")
+  }
 
-	if (missing(tr)) {
-		if (length(p) > 1000) {
-			tr <- as.vector(stats::quantile(p, 0:1000/1000))
-		} else {
-			tr <- p
-		}
-		if (length(a) > 1000) {
-			tr <- c(tr, as.vector(stats::quantile(a, 0:1000/1000)))
-		} else {
-			tr <- c(tr, a)
-		}
-		tr <- sort(unique( round(tr, 8)))
-		tr <- c( tr - 0.0001, tr[length(tr)] + c(0, 0.0001))
-	} else {
-		tr <- sort(as.vector(tr))
-	}
-	
-	N <- na + np
+  if (missing(tr)) {
+    if (length(p) > 1000) {
+      tr <- as.vector(stats::quantile(p, 0:1000/1000))
+    } else {
+      tr <- p
+    }
+    if (length(a) > 1000) {
+      tr <- c(tr, as.vector(stats::quantile(a, 0:1000/1000)))
+    } else {
+      tr <- c(tr, a)
+    }
+    tr <- sort(unique( round(tr, 8)))
+    tr <- c( tr - 0.0001, tr[length(tr)] + c(0, 0.0001))
+  } else {
+    tr <- sort(as.vector(tr))
+  }
 
-	xc <- methods::new("paModelEvaluation")
-	xc@presence = p
-	xc@absence = a
-		
-	R <- sum(rank(c(p, a))[1:np]) - (np*(np+1)/2)
-	auc <- R / (as.numeric(na) * as.numeric(np))
-	
-	cr <- try( stats::cor.test(c(p,a), c(rep(1, length(p)), rep(0, length(a))) ), silent=TRUE )
-	corc <- pcor <- NA
-	if (!inherits(cr, "try-error")) {
-		corc <- cr$estimate
-		pcor <- cr$p.value
-	} 
-	
-	res <- matrix(ncol=4, nrow=length(tr))
-	colnames(res) <- c("tp", "fp", "fn", "tn")
-	for (i in 1:length(tr)) {
-		res[i,1] <- length(p[p>=tr[i]])  # a  true positives
-		res[i,2] <- length(a[a>=tr[i]])  # b  false positives
-		res[i,3] <- length(p[p<tr[i]])    # c  false negatives
-		res[i,4] <- length(a[a<tr[i]])    # d  true negatives
-	}
-	xc@confusion = res
-	a = res[,1]
-	b = res[,2]
-	c = res[,3]
-	d = res[,4]
-# after Fielding and Bell	
-	np <- as.integer(np)
-	na <- as.integer(na)
-	prevalence = (a[1] + c[1]) / N
- # overall diagnostic power
-	ODP = (b[1] + d[1]) / N
-	xc@stats <- data.frame(np, na, prevalence, auc, cor=corc, pcor, ODP)
-	rownames(xc@stats) <- NULL
- # correct classification rate
-	CCR = (a + d) / N
- # sensitivity, or true positive rate
-	TPR = a / (a + c)
- # specificity, or true negative rate
-	TNR = d / (b + d)
- # False positive rate
-	FPR = b / (b + d)
- # False negative rate
-	FNR = c/(a + c)
-	PPP = a/(a + b)
-	NPP = d/(c + d)
- # misclassification rate
-	MCR = (b + c)/N
- # odds ratio
-	OR = (a*d)/(c*b)
+  N <- na + np
 
-	prA = (a+d)/N
-	prY = (a+b)/N * (a+c)/N
-	prN = (c+d)/N * (b+d)/N
-	prE = prY + prN
-	kappa = (prA - prE) / (1-prE)
-	xc@tr_stats <- data.frame(treshold=tr, kappa, CCR, TPR, TNR, FPR, FNR, PPP, NPP, MCR, OR)
+  xc <- methods::new("paModelEvaluation")
+  xc@presence = p
+  xc@absence = a
+
+  R <- sum(rank(c(p, a))[1:np]) - (np*(np+1)/2)
+  auc <- R / (as.numeric(na) * as.numeric(np))
+
+  cr <- try( stats::cor.test(c(p,a), c(rep(1, length(p)), rep(0, length(a))) ), silent=TRUE )
+  corc <- pcor <- NA
+  if (!inherits(cr, "try-error")) {
+    corc <- cr$estimate
+    pcor <- cr$p.value
+  }
+
+  res <- matrix(ncol=4, nrow=length(tr))
+  colnames(res) <- c("tp", "fp", "fn", "tn")
+  for (i in 1:length(tr)) {
+    res[i,1] <- length(p[p>=tr[i]])  # a  true positives
+    res[i,2] <- length(a[a>=tr[i]])  # b  false positives
+    res[i,3] <- length(p[p<tr[i]])    # c  false negatives
+    res[i,4] <- length(a[a<tr[i]])    # d  true negatives
+  }
+  xc@confusion = res
+  a = res[,1]
+  b = res[,2]
+  c = res[,3]
+  d = res[,4]
+  # after Fielding and Bell
+  np <- as.integer(np)
+  na <- as.integer(na)
+  prevalence = (a[1] + c[1]) / N
+  # overall diagnostic power
+  ODP = (b[1] + d[1]) / N
+  xc@stats <- data.frame(np, na, prevalence, auc, cor=corc, pcor, ODP)
+  rownames(xc@stats) <- NULL
+  # correct classification rate
+  CCR = (a + d) / N
+  # sensitivity, or true positive rate
+  TPR = a / (a + c)
+  # specificity, or true negative rate
+  TNR = d / (b + d)
+  # False positive rate
+  FPR = b / (b + d)
+  # False negative rate
+  FNR = c/(a + c)
+  PPP = a/(a + b)
+  NPP = d/(c + d)
+  # misclassification rate
+  MCR = (b + c)/N
+  # odds ratio
+  OR = (a*d)/(c*b)
+
+  prA = (a+d)/N
+  prY = (a+b)/N * (a+c)/N
+  prN = (c+d)/N * (b+d)/N
+  prE = prY + prN
+  kappa = (prA - prE) / (1-prE)
+  xc@tr_stats <- data.frame(treshold=tr, kappa, CCR, TPR, TNR, FPR, FNR, PPP, NPP, MCR, OR)
 
 
 
-	max_kappa <- tr[which.max(kappa)]
-	# maximum sum of the sensitivity (true positive rate) and specificity (true negative rate)
-	max_spec_sens <- tr[which.max(TPR + TNR)]
-	# no omission
-	no_omission <- tr[max(which(res[, "fn"] == 0))]
-	# Suggestions by Diego Nieto-Lugilde		
-	# equal prevalence
-	equal_prevalence = tr[which.min(abs(tr - prevalence))] 
-	# equal sensitivity and specificity
-	equal_sens_spec <- tr[which.min(abs(TPR - TNR))]
-		
-	xc@thresholds <- data.frame(max_kappa, max_spec_sens, no_omission,  equal_prevalence, equal_sens_spec)
+  max_kappa <- tr[which.max(kappa)]
+  # maximum sum of the sensitivity (true positive rate) and specificity (true negative rate)
+  max_spec_sens <- tr[which.max(TPR + TNR)]
+  # no omission
+  no_omission <- tr[max(which(res[, "fn"] == 0))]
+  # Suggestions by Diego Nieto-Lugilde
+  # equal prevalence
+  equal_prevalence = tr[which.min(abs(tr - prevalence))]
+  # equal sensitivity and specificity
+  equal_sens_spec <- tr[which.min(abs(TPR - TNR))]
 
-	return(xc)
+  xc@thresholds <- data.frame(max_kappa, max_spec_sens, no_omission,  equal_prevalence, equal_sens_spec)
+
+  return(xc)
 }
 
 
-setMethod ("show" , "paModelEvaluation", 
-	function(object) {
-		cat("@stats\n")
-		print(round(object@stats, 3))
-		cat("\n")
-		cat("@thresholds\n")
-		print(round(object@thresholds, 3))
-		cat("\n")
-		cat("@tr_stats\n")
-		x <- rbind(head(object@tr_stats, 4), tail(object@tr_stats, 3))
-		x <- round(x, 2)
-		x[4, ] <- "..."
-		print(x)		
-	}
-)	
+setMethod ("show" , "paModelEvaluation",
+           function(object) {
+             cat("@stats\n")
+             print(round(object@stats, 3))
+             cat("\n")
+             cat("@thresholds\n")
+             print(round(object@thresholds, 3))
+             cat("\n")
+             cat("@tr_stats\n")
+             x <- rbind(head(object@tr_stats, 4), tail(object@tr_stats, 3))
+             x <- round(x, 2)
+             x[4, ] <- "..."
+             print(x)
+           }
+)
 
 
 
 
 
-setMethod ("show" , "paModelEvaluation", 
-	function(object) {
-		cat("@stats\n")
-		print(round(object@stats, 3))
-		cat("\n")
-		cat("@thresholds\n")
-		print(round(object@thresholds, 3))
-		cat("\n")
-		cat("@tr_stats\n")
-		x <- rbind(head(object@tr_stats, 4), tail(object@tr_stats, 3))
-		x <- round(x, 2)
-		x[4, ] <- "..."
-		print(x)		
-	}
-)	
+setMethod ("show" , "paModelEvaluation",
+           function(object) {
+             cat("@stats\n")
+             print(round(object@stats, 3))
+             cat("\n")
+             cat("@thresholds\n")
+             print(round(object@thresholds, 3))
+             cat("\n")
+             cat("@tr_stats\n")
+             x <- rbind(head(object@tr_stats, 4), tail(object@tr_stats, 3))
+             x <- round(x, 2)
+             x[4, ] <- "..."
+             print(x)
+           }
+)
 
 
 
-setMethod("plot", signature(x="paModelEvaluation"), 
-	function(x, y="ROC", col="red", ...) {
-		if (y == "boxplot") {
-			prediction <- c(x@presence, x@absence)
-			group <- c(rep("presence", length(x@presence)), rep("absence", length(x@absence)) )
-			boxplot(prediction~group, data=data.frame(prediction, group), ...)
-		} else if (y == "ROC") {
-			txt = paste("AUC=", round(x@stats$auc,3))
-			plot(x@tr_stats$FPR, x@tr_stats$TPR, xlim=c(0,1), ylim=c(0,1), xlab="False postive rate", ylab="True positive rate", col=col, main=txt, ...)
-			lines(x@tr_stats$FPR, x@tr_stats$TPR, col=col)
-			lines(rbind(c(0,0), c(1,1)), lwd=2, col="grey")
-		} else if (y == "density") {
-			pr <- density(x@presence)
-			ab <- density(x@absence, bw=pr$bw )
-			yl = c(min(ab$y, pr$y), max(ab$y, pr$y))
-			xl = c(min(x@tr_stats$treshold), max(x@tr_stats$treshold))
-			plot(ab, main="", ylab=paste("Density. Bandwidth=",round(pr$bw,5),paste=""), xlab="predicted value", xlim=xl, ylim=yl, lwd=2, lty=2, col="blue", ...)
-			lines(pr, col="red", lwd=2)
-		} else if (y %in% colnames(x@tr_stats)) {
-			dat <- x@tr_stats[, y]
-			#mx = x@tr_stats$treshold[which.max(dat)]
-			#mn = x@tr_stats$treshold[which.min(dat)]
-			plot(x@tr_stats$treshold, dat, xlab="threshold", ylab=y, ...)
-			lines(x@tr_stats$treshold, dat, col=col)
-		} else {
-			stop("invalid option")
-		}
-	}	
+setMethod("plot", signature(x="paModelEvaluation"),
+          function(x, y="ROC", col="red", ...) {
+            if (y == "boxplot") {
+              prediction <- c(x@presence, x@absence)
+              group <- c(rep("presence", length(x@presence)), rep("absence", length(x@absence)) )
+              boxplot(prediction~group, data=data.frame(prediction, group), ...)
+            } else if (y == "ROC") {
+              txt = paste("AUC=", round(x@stats$auc,3))
+              plot(x@tr_stats$FPR, x@tr_stats$TPR, xlim=c(0,1), ylim=c(0,1), xlab="False postive rate", ylab="True positive rate", col=col, main=txt, ...)
+              lines(x@tr_stats$FPR, x@tr_stats$TPR, col=col)
+              lines(rbind(c(0,0), c(1,1)), lwd=2, col="grey")
+            } else if (y == "density") {
+              pr <- density(x@presence)
+              ab <- density(x@absence, bw=pr$bw )
+              yl = c(min(ab$y, pr$y), max(ab$y, pr$y))
+              xl = c(min(x@tr_stats$treshold), max(x@tr_stats$treshold))
+              plot(ab, main="", ylab=paste("Density. Bandwidth=",round(pr$bw,5),paste=""), xlab="predicted value", xlim=xl, ylim=yl, lwd=2, lty=2, col="blue", ...)
+              lines(pr, col="red", lwd=2)
+            } else if (y %in% colnames(x@tr_stats)) {
+              dat <- x@tr_stats[, y]
+              #mx = x@tr_stats$treshold[which.max(dat)]
+              #mn = x@tr_stats$treshold[which.min(dat)]
+              plot(x@tr_stats$treshold, dat, xlab="threshold", ylab=y, ...)
+              lines(x@tr_stats$treshold, dat, col=col)
+            } else {
+              stop("invalid option")
+            }
+          }
 )
 
 
 if (!isGeneric("threshold")) {
-	setGeneric("threshold", function(x, ...)
-		standardGeneric("threshold"))
-}	
+  setGeneric("threshold", function(x, ...)
+    standardGeneric("threshold"))
+}
 
 
 setMethod('threshold', signature(x='paModelEvaluation'),
-	function(x) {
-		x@thresholds
-	}
+          function(x) {
+            x@thresholds
+          }
 )
 
 

--- a/R/response.R
+++ b/R/response.R
@@ -13,7 +13,7 @@
 }
 
 
-varImportance <- function(model, data, vars=colnames(data), n=10) {
+varImportance <- function(model, data, vars=colnames(data), n=10, ...) {
 	RMSE <- matrix(nrow=n, ncol=length(vars))
 	colnames(RMSE) <- vars
 
@@ -24,21 +24,21 @@ varImportance <- function(model, data, vars=colnames(data), n=10) {
 		}
 	}
 
-	P <- predict(model, data)
+	P <- predict(model, data, ...)
 	for (i in 1:length(vars)) {
 		rd <- data
 		v <- vars[i]
 		for (j in 1:n) {
 			rd[[v]] <- sample(rd[[v]])
-			p <- predict(model, rd)
+			p <- predict(model, rd, ...)
 			RMSE[j,i] <- predicts::RMSE(P, p)
 		}
 	}
-	colMeans(RMSE) 
+	colMeans(RMSE)
 }
 
 
-partialResponse <- function(model, data, var=1, rng=NULL, nsteps=25) {
+partialResponse <- function(model, data, var=1, rng=NULL, nsteps=25, ...) {
 
 	if (missing(data)) {
 		data <- .get_model_data(model)
@@ -46,19 +46,19 @@ partialResponse <- function(model, data, var=1, rng=NULL, nsteps=25) {
 			stop("data argument cannot be missing when using this model type")
 		}
 	}
-	
+
 	if (is.numeric(var)) {
 		stopifnot(var > 0 & var <= ncol(data))
 		var <- names(data)[var]
 	} else {
 		stopifnot(all(var %in% names(data)))
 	}
-	
+
 	if (is.factor(data[[var]])) {
 		steps <- levels(data[[var]])
 	} else {
-		if (is.null(rng)) { 
-			rng <- range(data[[var]]) 
+		if (is.null(rng)) {
+			rng <- range(data[[var]])
 		}
 		increment <- (rng[2] - rng[1])/(nsteps-2)
 		steps <- seq(rng[1]-increment, rng[2]+increment, increment)
@@ -66,7 +66,7 @@ partialResponse <- function(model, data, var=1, rng=NULL, nsteps=25) {
 	res <- rep(NA, length(steps))
 	for (i in 1:length(steps)) {
 		data[[var]] <- steps[i]
-		p <- predict(model, data)
+		p <- predict(model, data, ...)
 		res[i] <- mean(p)
 	}
 	x <- data.frame(steps, res)
@@ -75,23 +75,23 @@ partialResponse <- function(model, data, var=1, rng=NULL, nsteps=25) {
 }
 
 
-partialResponse2 <- function(model, data, var, var2, var2levels, rng=NULL, nsteps=25) {
+partialResponse2 <- function(model, data, var, var2, var2levels, rng=NULL, nsteps=25, ...) {
 	if (is.factor(data[[var]])) {
 		steps <- levels(data[[var]])
 	} else {
-		if (is.null(rng)) { 
-			rng <- range(data[[var]]) 
+		if (is.null(rng)) {
+			rng <- range(data[[var]])
 		}
 		increment <- (rng[2] - rng[1])/(nsteps-2)
 		steps <- seq(rng[1]-increment, rng[2]+increment, increment)
 	}
 	res <- rep(NA, length(steps))
-	out <- data.frame(var=steps)	
+	out <- data.frame(var=steps)
 	for (v in var2levels) {
 		data[[var2]] <- v
 		for (i in 1:length(steps)) {
 			data[[var]] <- steps[i]
-			p <- stats::predict(model, data)
+			p <- stats::predict(model, data, ...)
 			res[i] <- mean(p)
 		}
 		out[[paste(var2, v, sep="_")]] <- res

--- a/man/response.Rd
+++ b/man/response.Rd
@@ -13,10 +13,10 @@ Get partial response data.
 
 
 \usage{
-partialResponse(model, data, var=1, rng=NULL, nsteps=25)
-partialResponse2(model, data, var, var2, var2levels, rng=NULL, nsteps=25)
+partialResponse(model, data, var=1, rng=NULL, nsteps=25, ...)
+partialResponse2(model, data, var, var2, var2levels, rng=NULL, nsteps=25, ...)
 }
- 
+
 \arguments{
   \item{model}{a model object}
   \item{data}{data.frame with data for all model variables}
@@ -25,6 +25,7 @@ partialResponse2(model, data, var, var2, var2levels, rng=NULL, nsteps=25)
   \item{var2levels}{character. The levels of the second variable to consider}
   \item{rng}{optional vector of two numbers to set the range or the variable}
   \item{nsteps}{positive integer. Number of steps to consider for the variable}
+  \item{\dots}{additional arguments to pass to \code{\link{predict}}, e.g. \code{n.trees} for GBM}
 }
 
 \value{

--- a/man/varImportance.Rd
+++ b/man/varImportance.Rd
@@ -12,14 +12,15 @@ Get variable importance.
 
 
 \usage{
-varImportance(model, data, vars=colnames(data), n=10)
+varImportance(model, data, vars=colnames(data), n=10, ...)
 }
- 
+
 \arguments{
   \item{model}{a model object}
   \item{data}{data.frame with data for all model variables}
   \item{vars}{character. The variables of interest}
   \item{n}{positive integer. Number of simulations}
+  \item{\dots}{additional arguments to pass to \code{\link{predict}}, e.g. \code{n.trees} for GBM}
 }
 
 \value{


### PR DESCRIPTION
e.g., `n.trees` is a relevant argument for GBM prediction, and it is actually a required argument when predicting with models computed with package `gbm3` (which `library(gbm)` now prompts users to switch to). Adding the `...` argument here makes it possible for `varImportance()` and `partialResponse()` to work for `gbm3` models.